### PR TITLE
fix: issue when no diff between last two commits

### DIFF
--- a/lib/analyzer_module.ex
+++ b/lib/analyzer_module.ex
@@ -11,9 +11,10 @@ defmodule AnalyzerModule do
   """
   @spec analyze(String.t() | list(), String.t()) :: tuple()
   def analyze(url, source) when is_binary(url) do
-    Temp.track!
+    Temp.track!()
 
     start_time = DateTime.utc_now()
+
     try do
       url = URI.decode(url)
 
@@ -109,7 +110,6 @@ defmodule AnalyzerModule do
         GitModule.delete_repo(repo)
       end
 
-
       end_time = DateTime.utc_now()
       duration = DateTime.diff(end_time, start_time)
 
@@ -189,7 +189,7 @@ defmodule AnalyzerModule do
            }
          }}
     after
-      Temp.cleanup
+      Temp.cleanup()
     end
   end
 

--- a/lib/git_helper.ex
+++ b/lib/git_helper.ex
@@ -133,6 +133,7 @@ defmodule GitHelper do
       get_contributor_counts(tail, accumulator)
     else
       maybe_new_key = Map.put_new(accumulator, String.trim(head), 0)
+
       {_num, new_value} =
         Map.get_and_update(maybe_new_key, head, fn current_value ->
           if current_value == nil do

--- a/lib/git_module.ex
+++ b/lib/git_module.ex
@@ -176,7 +176,12 @@ defmodule GitModule do
     cond do
       length(commits) >= 2 ->
         {:ok, diffs} = get_diff_2_commits(repo, commits)
-        GitHelper.parse_diff(diffs)
+
+        if diffs == [""] do
+          {:ok, 0, 0, 0}
+        else
+          GitHelper.parse_diff(diffs)
+        end
 
       length(commits) < 2 ->
         {:ok, 0, 0, 0}

--- a/lib/mix/tasks/bulk_analyze.ex
+++ b/lib/mix/tasks/bulk_analyze.ex
@@ -61,6 +61,5 @@ defmodule Mix.Tasks.Lei.BulkAnalyze do
             Mix.shell().info("\ninvalid file contents")
         end
     end
-
   end
 end

--- a/test/git_module_test.exs
+++ b/test/git_module_test.exs
@@ -85,7 +85,17 @@ defmodule GitModuleTest do
 
   test "get commit dates", context do
     dates = GitModule.get_commit_dates(context[:repo])
-    assert {:ok, [1231298600, 1208905906, 1208905647, 1208902657, 1208902186, 1208898811, 1208896913]} == dates
+
+    assert {:ok,
+            [
+              1_231_298_600,
+              1_208_905_906,
+              1_208_905_647,
+              1_208_902_657,
+              1_208_902_186,
+              1_208_898_811,
+              1_208_896_913
+            ]} == dates
   end
 
   test "get last commit date", context do


### PR DESCRIPTION
Fixes #38 - which was actually just a bug, not handling when there is no diff between 2 most recent comments.