### PR TITLE
feat: splits up the contributions for top10

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,17 +29,17 @@ the tolerance level, which you can easily override) and responds with a useful r
 {
   "state": "complete",
   "report": {
-    "uuid": "c3baa0fe-7463-11ea-9b27-acde48001122",
+    "uuid": "4d1e2b08-7b68-11ea-9ca1-88e9fe666193",
     "repos": [
       {
         "header": {
-          "uuid": "c3ba45be-7463-11ea-a2a8-acde48001122",
-          "start_time": "2020-04-01T21:57:09.307791Z",
+          "uuid": "4d1dbee8-7b68-11ea-93b9-88e9fe666193",
+          "start_time": "2020-04-10T20:15:34.912972Z",
           "source_client": "mix task",
           "repo": "https://github.com/facebook/react",
           "library_version": "",
-          "end_time": "2020-04-01T21:57:22.245416Z",
-          "duration": 13
+          "end_time": "2020-04-10T20:17:28.867848Z",
+          "duration": 114
         },
         "data": {
           "risk": "low",
@@ -47,49 +47,69 @@ the tolerance level, which you can easily override) and responds with a useful r
             "top10_contributors": [
               {
                 "name": "Paul O’Shannessy",
+                "merges": 959,
+                "email": "paul@oshannessy.com",
                 "contributions": 1777
               },
               {
                 "name": "Dan Abramov",
-                "contributions": 1377
-              },
-              {
-                "name": "Brian Vaughn",
-                "contributions": 1350
+                "merges": 86,
+                "email": "dan.abramov@gmail.com",
+                "contributions": 1356
               },
               {
                 "name": "Sophie Alpert",
-                "contributions": 1266
+                "merges": 392,
+                "email": "git@sophiebits.com",
+                "contributions": 1265
+              },
+              {
+                "name": "Brian Vaughn",
+                "merges": 101,
+                "email": "bvaughn@fb.com",
+                "contributions": 995
               },
               {
                 "name": "Sebastian Markbåge",
-                "contributions": 790
-              },
-              {
-                "name": "Andrew Clark",
-                "contributions": 711
+                "merges": 141,
+                "email": "sebastian@calyptus.eu",
+                "contributions": 803
               },
               {
                 "name": "Jim Sproch",
+                "merges": 327,
+                "email": "jsproch@fb.com",
                 "contributions": 456
               },
               {
+                "name": "Brian Vaughn",
+                "merges": 65,
+                "email": "brian.david.vaughn@gmail.com",
+                "contributions": 363
+              },
+              {
                 "name": "Dominic Gannaway",
-                "contributions": 355
+                "merges": 6,
+                "email": "trueadm@users.noreply.github.com",
+                "contributions": 336
               },
               {
                 "name": "Pete Hunt",
+                "merges": 126,
+                "email": "floydophone@gmail.com",
                 "contributions": 332
               },
               {
-                "name": "Cheng Lou",
-                "contributions": 222
+                "name": "Andrew Clark",
+                "merges": 2,
+                "email": "acdlite@fb.com",
+                "contributions": 264
               }
             ],
-            "recent_commit_size_in_percent_of_codebase": 3e-05,
+            "recent_commit_size_in_percent_of_codebase": 0.00032,
             "large_recent_commit_risk": "low",
             "functional_contributors_risk": "low",
-            "functional_contributors": 83,
+            "functional_contributors": 84,
             "functional_contributor_names": [
               "yiminghe",
               "Marshall Roch",
@@ -153,6 +173,7 @@ the tolerance level, which you can easily override) and responds with a useful r
               "Ben Newman",
               "jim",
               "Clement Hoang",
+              "Hristo Kanchev",
               "Scott Feeney",
               "Connor McSheffrey",
               "Brandon Dail",
@@ -176,7 +197,7 @@ the tolerance level, which you can easily override) and responds with a useful r
               "Jason Quense"
             ],
             "contributor_risk": "low",
-            "contributor_count": 1502,
+            "contributor_count": 1505,
             "commit_currency_weeks": 0,
             "commit_currency_risk": "low"
           },
@@ -184,70 +205,69 @@ the tolerance level, which you can easily override) and responds with a useful r
           "repo": "https://github.com/facebook/react",
           "project_types": {
             "node": [
-              "/tmp/lei-1585778229-6206-23kw46/react/fixtures/art/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/fixtures/attribute-behavior/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/fixtures/concurrent/time-slicing/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/fixtures/dom/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/fixtures/eslint/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/fixtures/eslint/proxy/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/fixtures/expiration/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/fixtures/fiber-debugger/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/fixtures/flight/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/fixtures/packaging/browserify/dev/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/fixtures/packaging/browserify/prod/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/fixtures/packaging/brunch/dev/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/fixtures/packaging/brunch/prod/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/fixtures/packaging/rjs/dev/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/fixtures/packaging/rjs/prod/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/fixtures/packaging/systemjs-builder/dev/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/fixtures/packaging/systemjs-builder/prod/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/fixtures/packaging/webpack-alias/dev/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/fixtures/packaging/webpack-alias/prod/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/fixtures/packaging/webpack/dev/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/fixtures/packaging/webpack/prod/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/fixtures/ssr/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/babel-plugin-react-jsx/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/create-subscription/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/dom-event-testing-library/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/eslint-plugin-react-hooks/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/jest-mock-scheduler/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/jest-react/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/legacy-events/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/react-art/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/react-cache/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/react-client/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/react-debug-tools/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/react-devtools-core/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/react-devtools-extensions/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/react-devtools-inline/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/react-devtools-shared/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/react-devtools-shared/src/node_modules/react-window/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/react-devtools-shell/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/react-devtools/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/react-dom/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/react-flight-dom-relay/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/react-flight-dom-webpack/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/react-interactions/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/react-is/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/react-native-renderer/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/react-noop-renderer/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/react-reconciler/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/react-refresh/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/react-server/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/react-test-renderer/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/react/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/scheduler/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/shared/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/packages/use-subscription/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/scripts/bench/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/scripts/eslint-rules/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/scripts/perf-counters/package.json",
-              "/tmp/lei-1585778229-6206-23kw46/react/scripts/release/package.json"
+              "/tmp/lei-1586549734-63434-1b1so9e/react/fixtures/art/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/fixtures/attribute-behavior/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/fixtures/concurrent/time-slicing/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/fixtures/dom/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/fixtures/eslint/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/fixtures/eslint/proxy/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/fixtures/expiration/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/fixtures/fiber-debugger/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/fixtures/flight/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/fixtures/packaging/browserify/dev/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/fixtures/packaging/browserify/prod/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/fixtures/packaging/brunch/dev/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/fixtures/packaging/brunch/prod/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/fixtures/packaging/rjs/dev/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/fixtures/packaging/rjs/prod/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/fixtures/packaging/systemjs-builder/dev/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/fixtures/packaging/systemjs-builder/prod/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/fixtures/packaging/webpack-alias/dev/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/fixtures/packaging/webpack-alias/prod/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/fixtures/packaging/webpack/dev/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/fixtures/packaging/webpack/prod/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/fixtures/ssr/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/create-subscription/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/dom-event-testing-library/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/eslint-plugin-react-hooks/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/jest-mock-scheduler/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/jest-react/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/legacy-events/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/react-art/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/react-cache/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/react-client/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/react-debug-tools/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/react-devtools-core/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/react-devtools-extensions/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/react-devtools-inline/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/react-devtools-shared/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/react-devtools-shared/src/node_modules/react-window/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/react-devtools-shell/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/react-devtools/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/react-dom/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/react-flight-dom-relay/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/react-flight-dom-webpack/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/react-interactions/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/react-is/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/react-native-renderer/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/react-noop-renderer/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/react-reconciler/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/react-refresh/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/react-server/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/react-test-renderer/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/react/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/scheduler/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/shared/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/packages/use-subscription/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/scripts/bench/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/scripts/eslint-rules/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/scripts/perf-counters/package.json",
+              "/tmp/lei-1586549734-63434-1b1so9e/react/scripts/release/package.json"
             ]
           },
           "git": {
-            "hash": "c80cd8ee27d24bb5b9a6136ede6875d13b9f1ba4",
+            "hash": "8e13f099ab0c820c6f97547ad08244340e074266",
             "default_branch": "refs/remotes/origin/master"
           },
           "config": {
@@ -271,9 +291,9 @@ the tolerance level, which you can easily override) and responds with a useful r
   },
   "metadata": {
     "times": {
-      "start_time": "2020-04-01T21:57:09.298319Z",
-      "end_time": "2020-04-01T21:57:22.259390Z",
-      "duration": 13
+      "start_time": "2020-04-10T20:15:34.901638Z",
+      "end_time": "2020-04-10T20:17:28.885951Z",
+      "duration": 114
     },
     "risk_counts": {
       "low": 1

--- a/lib/contributor.ex
+++ b/lib/contributor.ex
@@ -1,9 +1,7 @@
 defmodule Contributor do
-
   defstruct name: "",
             email: "",
             count: 0,
             merges: 0,
             commits: []
-
 end

--- a/lib/contributor.ex
+++ b/lib/contributor.ex
@@ -1,0 +1,9 @@
+defmodule Contributor do
+
+  defstruct name: "",
+            email: "",
+            count: 0,
+            merges: 0,
+            commits: []
+
+end

--- a/lib/git_helper.ex
+++ b/lib/git_helper.ex
@@ -92,15 +92,19 @@ defmodule GitHelper do
     |> Enum.map(fn contributor ->
       {name, email, count} = parse_header(contributor)
       {merges, commits} = parse_commits(contributor)
+
       {count, _} = Integer.parse(count)
-      %Contributor{name: String.trim(name),
-       email: String.trim(email),
-       count: count,
-       merges: merges,
-       commits: commits
+
+      %Contributor{
+        name: String.trim(name),
+        email: String.trim(email),
+        count: count,
+        merges: merges,
+        commits: commits
       }
     end)
   end
+
   defp split_shortlog(log) do
     log
     |> String.trim()
@@ -108,13 +112,18 @@ defmodule GitHelper do
   end
 
   defp parse_header(contributor) do
-    header = Regex.scan(~r{([^<]+)<([^;]*)>.\(([^:]+)\)}, contributor) |> Enum.at(0)
+    header =
+      contributor
+      |> String.split("\n")
+      |> Enum.at(0)
+      |> (&Regex.scan(~r{([^<]+)<([^;]*)>.\(([^:]+)\)}, &1)).()
+      |> Enum.at(0)
+
     {Enum.at(header, 1), Enum.at(header, 2), Enum.at(header, 3)}
   end
 
   defp parse_commits(contributor) do
-    [_|commits] =
-      String.split(contributor, "\n")
+    [_ | commits] = String.split(contributor, "\n")
 
     commits = Enum.map(commits, fn commit -> String.trim(commit) end)
     merges = Enum.count(commits, &(&1 =~ ~r/^(merge)+/i))

--- a/lib/git_module.ex
+++ b/lib/git_module.ex
@@ -221,9 +221,24 @@ defmodule GitModule do
     {:ok, map}
   end
 
+  def get_clean_contributions_map(repo) do
+    map =
+      Git.shortlog!(repo, ["-n", "-e", "HEAD"])
+      |> GitHelper.parse_shortlog()
+      |> Enum.map(fn contributor ->
+        %{name: contributor.name,
+          contributions: contributor.count,
+          merges: contributor.merges,
+          email: contributor.email,
+        }
+      end)
+
+    {:ok, map}
+  end
+
   @spec get_top10_contributors_map(Git.Repository.t()) :: {:ok, [any]}
   def get_top10_contributors_map(repo) do
-    {:ok, map} = get_contributions_map(repo)
+    {:ok, map} = get_clean_contributions_map(repo)
     map10 = Enum.take(map, 10)
     {:ok, map10}
   end

--- a/lib/git_module.ex
+++ b/lib/git_module.ex
@@ -226,10 +226,11 @@ defmodule GitModule do
       Git.shortlog!(repo, ["-n", "-e", "HEAD"])
       |> GitHelper.parse_shortlog()
       |> Enum.map(fn contributor ->
-        %{name: contributor.name,
+        %{
+          name: contributor.name,
           contributions: contributor.count,
           merges: contributor.merges,
-          email: contributor.email,
+          email: contributor.email
         }
       end)
 

--- a/test/analyzer_test.exs
+++ b/test/analyzer_test.exs
@@ -65,7 +65,7 @@ defmodule AnalyzerTest do
         :functional_contributors_risk => "critical",
         :large_recent_commit_risk => "low",
         :recent_commit_size_in_percent_of_codebase => 0.00368,
-        :top10_contributors => [%{contributions: 7, name: "Kit Plummer"}]
+        :top10_contributors => [%{contributions: 6, name: "Kit Plummer", email: "kplummer@blitz.local", merges: 0}, %{contributions: 1, email: "kplummer@blitz.(none)", merges: 0, name: "Kit Plummer"}]
       },
       :project_types => %{},
       :repo_size => "292K",

--- a/test/analyzer_test.exs
+++ b/test/analyzer_test.exs
@@ -65,7 +65,10 @@ defmodule AnalyzerTest do
         :functional_contributors_risk => "critical",
         :large_recent_commit_risk => "low",
         :recent_commit_size_in_percent_of_codebase => 0.00368,
-        :top10_contributors => [%{contributions: 6, name: "Kit Plummer", email: "kplummer@blitz.local", merges: 0}, %{contributions: 1, email: "kplummer@blitz.(none)", merges: 0, name: "Kit Plummer"}]
+        :top10_contributors => [
+          %{contributions: 6, name: "Kit Plummer", email: "kplummer@blitz.local", merges: 0},
+          %{contributions: 1, email: "kplummer@blitz.(none)", merges: 0, name: "Kit Plummer"}
+        ]
       },
       :project_types => %{},
       :repo_size => "292K",

--- a/test/git_module_test.exs
+++ b/test/git_module_test.exs
@@ -24,6 +24,7 @@ defmodule GitModuleTest do
     {:ok, kitrepo} = GitModule.clone_repo("https://github.com/kitplummer/kit", tmp_path)
 
     {:ok, this_repo} = GitModule.get_repo(".")
+
     [
       tmp_path: tmp_path,
       repo: repo,
@@ -87,11 +88,16 @@ defmodule GitModuleTest do
       %{contributions: 1, name: "MIURA Masahiro", email: "echochamber@gmail.com", merges: 0},
       %{contributions: 1, name: "0verse", email: "ali.h.caliskan@protonmail.com", merges: 0},
       %{contributions: 1, name: "degussa", email: "aron@mojang.com", merges: 0},
-      %{contributions: 1, email: "44509301+0verse@users.noreply.github.com", merges: 0, name: "0verse"}
+      %{
+        contributions: 1,
+        email: "44509301+0verse@users.noreply.github.com",
+        merges: 0,
+        name: "0verse"
+      }
     ]
 
     {:ok, result} = GitModule.get_clean_contributions_map(kitrepo)
-    assert Enum.at(expected,1) == Enum.at(result,1)
+    assert Enum.at(expected, 1) == Enum.at(result, 1)
   end
 
   # test "wip" do

--- a/test/git_module_test.exs
+++ b/test/git_module_test.exs
@@ -91,7 +91,7 @@ defmodule GitModuleTest do
     ]
 
     {:ok, result} = GitModule.get_clean_contributions_map(kitrepo)
-    assert expected == result
+    assert Enum.at(expected,1) == Enum.at(result,1)
   end
 
   # test "wip" do

--- a/test/git_module_test.exs
+++ b/test/git_module_test.exs
@@ -23,13 +23,15 @@ defmodule GitModuleTest do
 
     {:ok, kitrepo} = GitModule.clone_repo("https://github.com/kitplummer/kit", tmp_path)
 
+    {:ok, this_repo} = GitModule.get_repo(".")
     [
       tmp_path: tmp_path,
       repo: repo,
       tag_repo: tag_repo,
       bitbucket_repo: bitbucket_repo,
       gitlab_repo: gitlab_repo,
-      kitrepo: kitrepo
+      kitrepo: kitrepo,
+      this_repo: this_repo
     ]
   end
 
@@ -61,17 +63,35 @@ defmodule GitModuleTest do
     {:ok, maps} = GitModule.get_contributions_map(kitrepo)
 
     expected_array = [
-      %{name: "Ben Morris", contributions: 358},
-      %{name: "Kit Plummer", contributions: 64},
-      %{name: "Tyler Bezera", contributions: 6},
-      %{name: "Jakub Stasiak", contributions: 4},
-      %{name: "0verse", contributions: 2},
-      %{name: "pixeljoelson", contributions: 2},
-      %{name: "degussa", contributions: 1},
-      %{name: "MIURA Masahiro", contributions: 1}
+      %{contributions: 358, name: "Ben Morris"},
+      %{contributions: 64, name: "Kit Plummer"},
+      %{contributions: 6, name: "Tyler Bezera"},
+      %{contributions: 4, name: "Jakub Stasiak"},
+      %{contributions: 2, name: "pixeljoelson"},
+      %{contributions: 1, name: "MIURA Masahiro"},
+      %{contributions: 1, name: "0verse"},
+      %{contributions: 1, name: "degussa"},
+      %{contributions: 1, name: "0verse"}
     ]
 
     assert Enum.at(expected_array, 0) == Enum.at(maps, 0)
+  end
+
+  test "get cleaned contribution map", %{kitrepo: kitrepo} do
+    expected = [
+      %{contributions: 358, name: "Ben Morris", email: "ben@bendmorris.com", merges: 2},
+      %{contributions: 64, name: "Kit Plummer", email: "kitplummer@gmail.com", merges: 4},
+      %{contributions: 6, name: "Tyler Bezera", email: "TylerJessilynn@gmail.com", merges: 0},
+      %{contributions: 4, name: "Jakub Stasiak", email: "jakub@stasiak.at", merges: 0},
+      %{contributions: 2, name: "pixeljoelson", email: "pixeljoelson@gmail.com", merges: 0},
+      %{contributions: 1, name: "MIURA Masahiro", email: "echochamber@gmail.com", merges: 0},
+      %{contributions: 1, name: "0verse", email: "ali.h.caliskan@protonmail.com", merges: 0},
+      %{contributions: 1, name: "degussa", email: "aron@mojang.com", merges: 0},
+      %{contributions: 1, email: "44509301+0verse@users.noreply.github.com", merges: 0, name: "0verse"}
+    ]
+
+    {:ok, result} = GitModule.get_clean_contributions_map(kitrepo)
+    assert expected == result
   end
 
   # test "wip" do


### PR DESCRIPTION
Updates the top10 output to break out "merge" commits from all commits for a basic understanding of accounts that are just PR/MR processors.  Also now include the email address to identify potential commits that are actually the same developer.