### PR TITLE
Feature/same person contributors

### DIFF
--- a/lib/contributor.ex
+++ b/lib/contributor.ex
@@ -4,4 +4,7 @@ defmodule Contributor do
             count: 0,
             merges: 0,
             commits: []
+
+  @type t :: %__MODULE__{
+    name: String.t(), email: String.t(), count: integer, merges: integer, commits: [String.t()]}
 end

--- a/lib/git_helper.ex
+++ b/lib/git_helper.ex
@@ -7,6 +7,8 @@ defmodule GitHelper do
   Collection of lower-level functions for analyzing outputs from git command.
   """
 
+  @type contrib_count :: %{String.t => integer}
+
   @doc """
       parse_diff/1: returns the relevant information contained in the last array position of a diff array
   """
@@ -74,6 +76,7 @@ defmodule GitHelper do
   @doc """
       det_filtered_contributor_count/2: Gets the resolved list of contributers, return count and list
   """
+  @spec get_filtered_contributor_count(contrib_count, non_neg_integer) :: {:ok, non_neg_integer, [contrib_count]}
   def get_filtered_contributor_count(map, total) do
     filtered_list =
       Enum.filter(
@@ -173,6 +176,7 @@ defmodule GitHelper do
     {:ok, accumulator}
   end
 
+  @spec get_contributor_counts([any], contrib_count) :: {:ok, [contrib_count], non_neg_integer}
   defp get_contributor_counts([head | tail], accumulator) do
     if head == "" do
       get_contributor_counts(tail, accumulator)

--- a/lib/git_helper.ex
+++ b/lib/git_helper.ex
@@ -218,7 +218,7 @@ defmodule GitHelper do
     #   for now, just the first one
     name_list = for a <- cur_contrib, do: a.name
     best_name =
-      Enum.sort_by(name_list, &name_sorter/1, :desc)
+      Enum.sort_by(name_list, &name_sorter/1, &>=/2)
       |> Enum.at(0)
     # Create the new contributor object
     contrib_ret = %Contributor{

--- a/lib/git_module.ex
+++ b/lib/git_module.ex
@@ -202,10 +202,14 @@ defmodule GitModule do
 
   @spec get_contributor_distribution(Git.Repository.t()) :: {:ok, map, non_neg_integer}
   def get_contributor_distribution(repo) do
-    contributors = Git.log!(repo, ["--pretty=format:%an"])
-    contributors_list = String.split(contributors, "\n")
-    total_contributions = Kernel.length(contributors_list)
-    {:ok, counts} = GitHelper.get_contributor_counts(contributors_list)
+    {:ok, contributors} = get_contributors(repo)
+    # Helper function
+    get_counts = fn contrib -> contrib.count end
+    # Calcualte for each
+    counts_kwlist = for a <- contributors, do: {a.name, get_counts.(a)}
+    counts = Enum.into(counts_kwlist, %{})
+    # Calculate for all
+    total_contributions = Enum.sum(for a <- contributors, do: get_counts.(a))
     {:ok, counts, total_contributions}
   end
 
@@ -220,16 +224,13 @@ defmodule GitModule do
   get_contributions_map/1: returns a map of contributions per git user
   note: this map is unfiltered, dupes aren't identified
   """
+  @spec get_contributions_map(Git.Repository.t) :: {:ok, [%{contributions: non_neg_integer,
+                                                            name: String.t}]}
   def get_contributions_map(repo) do
-    map =
-      Git.shortlog!(repo, ["-s", "-n", "HEAD"])
-      |> (&Regex.scan(~r{([0-9]+)\t(\w.*)}, &1)).()
-      |> Enum.map(fn x ->
-        k = Enum.at(x, 2)
-        v = String.to_integer(Enum.at(x, 1))
-        %{:name => k, :contributions => v}
-      end)
-
+    {:ok, contrib} = get_contributors(repo)
+    map = Enum.map(
+      contrib,
+      fn x -> %{:name => x.name, :contributions => x.count} end)
     {:ok, map}
   end
 
@@ -256,10 +257,20 @@ defmodule GitModule do
     {:ok, map}
   end
 
+  @doc """
+      get_top10_contributors_map/1: Gets the top 10 contributors and returns it
+      as a list of contributors with the commits list stripped from the map.
+  """
   @spec get_top10_contributors_map(Git.Repository.t()) :: {:ok, [any]}
   def get_top10_contributors_map(repo) do
-    {:ok, map} = get_clean_contributions_map(repo)
-    map10 = Enum.take(map, 10)
+    {:ok, contrib} = get_contributors(repo)
+    map10 =
+      Enum.sort_by(contrib, &(&1.count), :desc)
+      |> Stream.take(10)
+      |> Stream.map(fn x ->
+          Map.drop(x, [:commits, :__struct__])
+        end)
+      |> Enum.to_list()
     {:ok, map10}
   end
 

--- a/lib/git_module.ex
+++ b/lib/git_module.ex
@@ -51,7 +51,6 @@ defmodule GitModule do
   get_contributors_count/1: returns the number of contributors for
   a given Git repo
   """
-
   def get_contributor_count(repo) do
     count =
       Git.shortlog!(repo, ["-s", "-n", "HEAD", "--"])
@@ -193,6 +192,14 @@ defmodule GitModule do
     end
   end
 
+  @spec get_contributors(Git.Repository.t()) :: {:ok, [Contributor.t()]}
+  def get_contributors(repo) do
+    list =
+      Git.shortlog!(repo, ["-n", "-e", "HEAD", "--"])
+      |> GitHelper.parse_shortlog()
+    {:ok, list}
+  end
+
   @spec get_contributor_distribution(Git.Repository.t()) :: {:ok, map, non_neg_integer}
   def get_contributor_distribution(repo) do
     contributors = Git.log!(repo, ["--pretty=format:%an"])
@@ -280,3 +287,4 @@ defmodule GitModule do
     end)
   end
 end
+

--- a/lib/git_module.ex
+++ b/lib/git_module.ex
@@ -205,8 +205,9 @@ defmodule GitModule do
     {:ok, contributors} = get_contributors(repo)
     # Helper function
     get_counts = fn contrib -> contrib.count end
+    get_signoff = fn contrib -> contrib.name <> " <" <> contrib.email <> ">" end
     # Calcualte for each
-    counts_kwlist = for a <- contributors, do: {a.name, get_counts.(a)}
+    counts_kwlist = for a <- contributors, do: {get_signoff.(a), get_counts.(a)}
     counts = Enum.into(counts_kwlist, %{})
     # Calculate for all
     total_contributions = Enum.sum(for a <- contributors, do: get_counts.(a))
@@ -268,7 +269,10 @@ defmodule GitModule do
       Enum.sort_by(contrib, &(&1.count), :desc)
       |> Stream.take(10)
       |> Stream.map(fn x ->
-          Map.drop(x, [:commits, :__struct__])
+          Map.put(x, :contributions, x.count)
+        end)
+      |> Stream.map(fn x ->
+          Map.drop(x, [:commits, :count, :__struct__])
         end)
       |> Enum.to_list()
     {:ok, map10}

--- a/lib/git_module.ex
+++ b/lib/git_module.ex
@@ -266,7 +266,7 @@ defmodule GitModule do
   def get_top10_contributors_map(repo) do
     {:ok, contrib} = get_contributors(repo)
     map10 =
-      Enum.sort_by(contrib, &(&1.count), :desc)
+      Enum.sort_by(contrib, &(&1.count), &>=/2)
       |> Stream.take(10)
       |> Stream.map(fn x ->
           Map.put(x, :contributions, x.count)

--- a/test/analyzer_test.exs
+++ b/test/analyzer_test.exs
@@ -82,6 +82,7 @@ defmodule AnalyzerTest do
     assert expected_data[:results] == repo_data[:data][:results]
   end
 
+  @tag timeout: 180000
   test "get multi report mixed risks" do
     {:ok, report} =
       AnalyzerModule.analyze(

--- a/test/analyzer_test.exs
+++ b/test/analyzer_test.exs
@@ -60,7 +60,7 @@ defmodule AnalyzerTest do
         :commit_currency_weeks => context[:weeks],
         :contributor_count => 1,
         :contributor_risk => "critical",
-        :functional_contributor_names => ["Kit Plummer"],
+        :functional_contributor_names => ["Kit Plummer <kplummer@blitz.local>"],
         :functional_contributors => 1,
         :functional_contributors_risk => "critical",
         :large_recent_commit_risk => "low",

--- a/test/git_module_test.exs
+++ b/test/git_module_test.exs
@@ -219,8 +219,8 @@ defmodule GitModuleTest do
 
     values = Map.values(contributor_distribution)
     assert total == 7
-    assert Enum.at(values, 0) == 7
-    assert Map.fetch(contributor_distribution, "Kit Plummer") == {:ok, 7}
+    assert values == [1, 6]
+    assert Map.fetch(contributor_distribution, "Kit Plummer <kplummer@blitz.local>") == {:ok, 6}
 
     {:ok, t_contributor_distribution, t_total} =
       GitModule.get_contributor_distribution(context[:tag_repo])
@@ -235,9 +235,10 @@ defmodule GitModuleTest do
              2,
              1,
              234,
-             5,
              1,
-             200,
+             4,
+             1,
+             204,
              1,
              1,
              9,
@@ -249,72 +250,70 @@ defmodule GitModuleTest do
              1,
              1,
              3,
-             4,
              3,
              2
-           ]
+    ]
 
     assert t_total == 524
 
     {:ok, bb_contributor_distribution, bb_total} =
       GitModule.get_contributor_distribution(context[:bitbucket_repo])
 
-    assert Map.values(bb_contributor_distribution) == [30, 2]
+    assert Map.values(bb_contributor_distribution) == [3, 29]
     assert bb_total == 32
 
     {:ok, gl_contributor_distribution, gl_total} =
       GitModule.get_contributor_distribution(context[:gitlab_repo])
 
     assert Map.values(gl_contributor_distribution) == [
+             3,
+             1,
              1,
              2,
-             10,
-             1,
-             2,
-             2,
-             22,
-             22,
+             11,
              5,
+             7,
              1,
-             1,
+             2,
              6,
+             12,
+             2,
+             2,
+             1,
+             1,
+             3,
+             1,
              3,
              11,
-             3,
-             2,
-             1,
-             1,
-             1,
+             5,
              35,
-             29,
+             7,
              1,
-             1,
-             6,
-             1,
-             1,
-             14,
+             2,
              4,
-             11,
+             4,
+             1,
+             1,
+             1,
+             2,
+             2,
+             28,
+             6,
+             6,
+             14,
+             1,
+             2,
+             24,
+             1,
+             3,
+             22,
              1,
              5,
              1,
-             2,
-             3,
-             2,
-             6,
-             8,
-             1,
-             17,
-             5,
-             1,
              11,
-             1,
-             2,
-             3,
-             1,
-             6,
-             5
-           ]
+             5,
+             11
+    ]
 
     assert gl_total == 281
   end


### PR DESCRIPTION
Feature to merge contributors that use the same email but have different names provided. This could be due to using first-last name in one place vs username in another.

Also including the email in the functional contributor list as a sign-off in case there are multiple emails used for the same person.

This caused a change in the merging logic so the tests needed to be updated to account for it.