### PR TITLE
fix: handle bad regex in email with simple split

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -3,7 +3,7 @@
 # the BSD 3-Clause license. See the LICENSE file for details.
 
 use Mix.Config
-config :logger, level: :error
+config :logger, level: :debug
 
 config :lowendinsight,
   ## Contributor in terms of discrete users

--- a/lib/analyzer_module.ex
+++ b/lib/analyzer_module.ex
@@ -97,12 +97,10 @@ defmodule AnalyzerModule do
       {:ok, delta_risk} = RiskLogic.commit_currency_risk(weeks)
 
       # Get risk rating for size of last commit
-
       {:ok, lines_percent, _file_percent} = GitModule.get_recent_changes(repo)
       {:ok, changes_risk} = RiskLogic.commit_change_size_risk(lines_percent)
 
       # get risk rating for number of contributors with over a certain percentage of commits
-
       {:ok, num_filtered_contributors, functional_contributors} =
         GitModule.get_functional_contributors(repo)
 

--- a/lib/git_helper.ex
+++ b/lib/git_helper.ex
@@ -6,7 +6,7 @@ defmodule GitHelper do
   @moduledoc """
   Collection of lower-level functions for analyzing outputs from git command.
   """
-
+  require Logger
   @type contrib_count :: %{String.t() => integer}
 
   @doc """
@@ -97,6 +97,7 @@ defmodule GitHelper do
     split_shortlog(log)
     |> Enum.map(fn contributor ->
       {name, email, count} = parse_header(contributor)
+
       {merges, commits} = parse_commits(contributor)
 
       {count, _} = Integer.parse(count)
@@ -127,7 +128,15 @@ defmodule GitHelper do
 
     cond do
       length(header) == 0 ->
-        {"Could not process", "Could not process", "Could not process"}
+        ## Simple split - email validation issue lies here
+        split =
+          contributor
+          |> String.split("\n")
+          |> Enum.at(0)
+          |> String.split(" ")
+
+        count = Regex.run(~r/\((.*)\)/, Enum.at(split, 2)) |> Enum.at(1)
+        {Enum.at(split, 0), Enum.at(split, 1), count}
 
       true ->
         header = Enum.at(header, 0)

--- a/lib/git_helper.ex
+++ b/lib/git_helper.ex
@@ -128,15 +128,8 @@ defmodule GitHelper do
 
     cond do
       length(header) == 0 ->
-        ## Simple split - email validation issue lies here
-        split =
-          contributor
-          |> String.split("\n")
-          |> Enum.at(0)
-          |> String.split(" ")
-
-        count = Regex.run(~r/\((.*)\)/, Enum.at(split, 2)) |> Enum.at(1)
-        {Enum.at(split, 0), Enum.at(split, 1), count}
+        Logger.error("Failed to process: " <> contributor)
+        {"Could not process", "Could not process", "0"}
 
       true ->
         header = Enum.at(header, 0)

--- a/lib/git_module.ex
+++ b/lib/git_module.ex
@@ -6,6 +6,7 @@ defmodule GitModule do
   @moduledoc """
   Collections of functions for interacting with the `git` command to perform queries.
   """
+  require Logger
 
   @doc """
   clone_repo/2: clones the repo
@@ -345,7 +346,7 @@ defmodule GitModule do
   # we need to manually parse it out here
 
   @spec git_log_split(Git.Repository.t(), [String.t()]) :: [String.t()]
-  defp git_log_split(repo, args \\ []) do
+  defp git_log_split(repo, args) do
     Git.log!(repo, args)
     |> String.split("\n")
     |> Enum.filter(fn x ->

--- a/lib/hex/hex_scanner.ex
+++ b/lib/hex/hex_scanner.ex
@@ -9,9 +9,6 @@ defmodule Hex.Scanner do
   Scanner scans for mix dependencies to run analysis on.
   """
 
-  @doc """
-  scan: called when mix? is false, returning an empty list and 0.
-  """
   @spec scan(boolean(), map) :: {[], 0}
   def scan(mix?, _project_types) when mix? == false, do: {[], 0}
 

--- a/lib/time_helper.ex
+++ b/lib/time_helper.ex
@@ -75,9 +75,6 @@ defmodule TimeHelper do
     {:ok, accumulator}
   end
 
-  @doc """
-  sum_ts_diff/2
-  """
   @spec sum_ts_diff([any], non_neg_integer) :: {:ok, non_neg_integer}
   def sum_ts_diff([head_1 | tail], accumulator) do
     [head_2 | _next_tail] = tail
@@ -86,9 +83,6 @@ defmodule TimeHelper do
     sum_ts_diff(tail, timestamp_2 - timestamp_1 + accumulator)
   end
 
-  @doc """
-  sum_ts_diff/1
-  """
   @spec sum_ts_diff([any]) :: {:ok, non_neg_integer}
   def sum_ts_diff(list) do
     sum_ts_diff(list, 0)

--- a/test/git_helper_test.exs
+++ b/test/git_helper_test.exs
@@ -46,7 +46,7 @@ defmodule GitHelperTest do
 
   @tag :helper
   test "semicolon error", %{e_with_semi: e_with_semi} do
-    assert {"Could not process", "Could not process", "Could not process"} =
+    assert {"Could not process", "Could not process", "0"} =
              GitHelper.parse_header(e_with_semi)
   end
 


### PR DESCRIPTION
Fixes #105 - where totally invalid email breaks things. 