### PR TITLE
Repo size release

### DIFF
--- a/lib/git_module.ex
+++ b/lib/git_module.ex
@@ -304,17 +304,6 @@ defmodule GitModule do
   @spec get_repo_size(Git.Repository.t()) :: {:ok, String.t()}
   def get_repo_size(repo) do
     space =
-      elem(System.cmd("du", ["-sh", "#{repo.path}"]), 0)
-      |> String.split("\t")
-      |> List.first()
-      |> String.trim()
-
-    {:ok, space}
-  end
-
-  @spec get_repo_size2(Git.Repository.t()) :: {:ok, String.t()}
-  def get_repo_size2(repo) do
-    space =
       elem(System.cmd("git", ["count-objects"], cd: repo.path), 0)
       |> String.trim()
       |> String.split(",")

--- a/mix.exs
+++ b/mix.exs
@@ -9,8 +9,8 @@ defmodule GithubModule.MixProject do
     [
       app: :lowendinsight,
       description: description(),
-      version: "0.6.5",
-      elixir: "~> 1.9",
+      version: "0.6.6",
+      elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       package: package(),


### PR DESCRIPTION
Switches from using `du` to `git count-objects` to determine repo size.  Should reduce the fs load.